### PR TITLE
Fix a typo

### DIFF
--- a/val-for-swift-users.md
+++ b/val-for-swift-users.md
@@ -69,7 +69,7 @@ where Self: MutableCollection, Element: Comparable
 }
 ```
 
-*Note: `&` is simply a marker required by the languages when a value is mutated, just like it is a marker for arguments passed to `inout` parameters in Swift.*
+*Note: `&` is simply a marker required by the language when a value is mutated, just like it is a marker for arguments passed to `inout` parameters in Swift.*
 
 Notice that, unlike in Swift, `start_index` is a method rather than a property.
 The reason is that, in Val, functions and methods *return* values while a properties and subscripts *project* one.


### PR DESCRIPTION
Note that the same typo appears here:

https://tour.val-lang.dev/functions-and-methods

I cannot find a github source file for that page, though, so I can't figure out how to submit a PR.

Also, that page has a few more typos I noticed:

```
1.

A function are blocks of reusable code that performs a single action
^^^^^^^^^^^^^^

2.

variant as the receiver is no longer used aftertward
                                          ^^^^^^^^^^

3.

At the call site, the compiler determines the variant to apply depending on the context of the call. In this example, the first call applies the inout variant as the receiver has been marked for mutation. The second call applies the sink variant as the receiver is no longer used aftertward.

"second" should be "third"
```